### PR TITLE
Fix type imports

### DIFF
--- a/index.d.mts
+++ b/index.d.mts
@@ -1,3 +1,3 @@
-import getAsyncFunction = require('.');
+import getAsyncFunction = require('./index.js');
 
 export default getAsyncFunction;


### PR DESCRIPTION
ESM imports require a file extension. Also directory imports don’t resolve to `index.js`. This goes for source code as well as type definitions.

Modern module resolution settings validate this. The correct `"moduleResolution"` value for libraries that target Node.js 16 or lower is `"Node16"`. For libraries that target Node.js 18 or greater should set it to `"Node18"` or `"NodeNext"`. For code that gets bundled, the correct option is `"Preserve"`. All other options are outdated.

The config in `@ljarb/tsconfig/node` sets this correctly, but it contains a syntax error.