### PR TITLE
[meta] Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"function",
 		"native"
 	],
-	"author": "Jordan Harbamd <ljharb@gmail.com>",
+	"author": "Jordan Harband <ljharb@gmail.com>",
 	"license": "MIT",
 	"bugs": {
 		"url": "https://github.com/ljharb/async-function/issues"


### PR DESCRIPTION
I noticed this problem while looking at the authors for deps on eslint-plugin-import 😅  

This problem is also present on the package.json of https://github.com/TimothyGu/generator-function